### PR TITLE
fix: enhance updater script command and output parsing for update checks

### DIFF
--- a/simkl_mps/tray_win.py
+++ b/simkl_mps/tray_win.py
@@ -302,7 +302,17 @@ Tips:
         try:
             if system == 'win32':
                 # Add -Silent parameter to prevent the updater from showing its own notifications
-                command = ["powershell", "-ExecutionPolicy", "Bypass", "-File", str(updater_path), "-CheckOnly", "-Silent"]
+                command = [
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(updater_path),
+                    "-CheckOnly",
+                    "-Silent"
+                ]
                 # Hide PowerShell window
                 startupinfo = subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
@@ -328,6 +338,14 @@ Tips:
             stderr = process.stderr.strip()
             exit_code = process.returncode
 
+            parsed_output = ""
+            if stdout:
+                for line in stdout.splitlines():
+                    line = line.strip()
+                    if line.startswith("UPDATE_AVAILABLE:") or line.startswith("NO_UPDATE:"):
+                        parsed_output = line
+                        break
+
             logger.info(f"Update check script exited with code: {exit_code}")
             logger.debug(f"Update check stdout: {stdout}")
             if stderr:
@@ -345,9 +363,9 @@ Tips:
                     self.show_notification("Update Error", f"Failed to run update check script (Code: {exit_code}).")
 
             # Process stdout if exit code was 0
-            elif stdout.startswith("UPDATE_AVAILABLE:"):
+            elif parsed_output.startswith("UPDATE_AVAILABLE:"):
                 try:
-                    parts = stdout.split(" ", 2) # UPDATE_AVAILABLE: <version> <url>
+                    parts = parsed_output.split(" ", 2) # UPDATE_AVAILABLE: <version> <url>
                     new_version = parts[1]
                     url = parts[2]
                     logger.info(f"Update found: Version {new_version}")
@@ -363,15 +381,15 @@ Tips:
                     webbrowser.open(url)
                     
                 except IndexError:
-                    logger.error(f"Could not parse UPDATE_AVAILABLE string: {stdout}")
+                    logger.error(f"Could not parse UPDATE_AVAILABLE string: {parsed_output}")
                     self.show_notification("Update Error", "Failed to parse update information.")
-            elif stdout.startswith("NO_UPDATE:"):
+            elif parsed_output.startswith("NO_UPDATE:"):
                 try:
-                    version = stdout.split(" ", 1)[1]
+                    version = parsed_output.split(" ", 1)[1]
                     logger.info(f"No update available. Current version: {version}")
                     self.show_notification("No Updates Available", f"You are already running the latest version ({version}).")
                 except IndexError:
-                     logger.error(f"Could not parse NO_UPDATE string: {stdout}")
+                     logger.error(f"Could not parse NO_UPDATE string: {parsed_output}")
                      self.show_notification("No Updates Available", "You are already running the latest version.")
             else:
                 # Unexpected output


### PR DESCRIPTION
This pull request improves the update checking logic in `simkl_mps/tray_win.py` to make the PowerShell command invocation more robust and to better parse and handle the output from the updater script. The changes focus on ensuring the updater runs in a more controlled environment and that its output is parsed reliably before acting on it.

**PowerShell invocation improvements:**
* The PowerShell command used to check for updates now explicitly uses `powershell.exe` with `-NoProfile` and `-NonInteractive` flags, making the updater run in a cleaner, non-interactive environment.

**Output parsing and handling improvements:**
* The script now parses the updater's output line by line, looking specifically for lines starting with `UPDATE_AVAILABLE:` or `NO_UPDATE:`, and only processes these lines, improving robustness against unexpected output.
* All subsequent logic for update notifications and error handling now uses the parsed output line instead of the full stdout, reducing the risk of misparsing. This includes determining if an update is available, extracting version and URL information, and handling errors when parsing fails. [[1]](diffhunk://#diff-7d7e0f912608b0fc44561ce623f1e954cb0a2c8ae313b5de7422eb253722e615L348-R368) [[2]](diffhunk://#diff-7d7e0f912608b0fc44561ce623f1e954cb0a2c8ae313b5de7422eb253722e615L366-R392)